### PR TITLE
fix(matcher): cambios en las tarjetas del matcher

### DIFF
--- a/components/matcher/BookCard.tsx
+++ b/components/matcher/BookCard.tsx
@@ -1,7 +1,6 @@
 import { Badge, BadgeText } from '@/components/ui/badge';
 import { Box } from '@/components/ui/box';
 import { Card } from '@/components/ui/card';
-import { Heading } from '@/components/ui/heading';
 import { HStack } from '@/components/ui/hstack';
 import { Image } from '@/components/ui/image';
 import { Text } from '@/components/ui/text';
@@ -19,6 +18,36 @@ const CONDITION_LABELS: Record<BookCondition, string> = {
   POOR: 'Malo',
 };
 
+const normalizeText = (value: string) => value.replace(/\s+/g, ' ').trim();
+
+const pickVisibleGenres = (
+  genres: Array<{ id: number; name: string }>,
+  compact: boolean,
+) => {
+  // Menos badges visibles para mantener la tarjeta compacta.
+  // Si no caben, el resto se resume con +N.
+  const maxSlots = compact ? 2 : 4;
+  const charBudget = compact ? 18 : 26;
+
+  const visible: Array<{ id: number; name: string }> = [];
+  let used = 0;
+
+  for (const genre of genres) {
+    if (visible.length >= maxSlots) break;
+
+    const cost = normalizeText(genre.name).length + 2;
+    if (visible.length > 0 && used + cost > charBudget) break;
+
+    visible.push(genre);
+    used += cost;
+  }
+
+  return {
+    visibleGenres: visible,
+    hiddenGenresCount: Math.max(0, genres.length - visible.length),
+  };
+};
+
 interface BookCardProps {
   card: MatcherCard;
   onTap?: () => void;
@@ -29,36 +58,48 @@ export default function BookCard({ card, onTap }: BookCardProps) {
   const colorScheme = useColorScheme();
   const isDark = colorScheme === 'dark';
 
-  const { cardWidth, cardHeight, cardMarginTop } = useMemo(() => {
+  const { cardWidth, cardHeight } = useMemo(() => {
     const config = MATCHER_LAYOUT;
-    
+
     const width = SCREEN_WIDTH * config.card.widthPercent;
     const height = width * config.card.heightRatio;
-    const marginTop = SCREEN_HEIGHT * config.card.marginTopPercent;
 
     return {
       cardWidth: width,
       cardHeight: height,
-      cardMarginTop: marginTop,
     };
   }, [SCREEN_WIDTH, SCREEN_HEIGHT]);
 
   const { book, owner, distanceKm } = card;
   const heroPhoto = book.photos[0]?.url;
 
+  const isCompact = SCREEN_WIDTH < 390;
+
+  // Reducido para quitar hueco blanco excesivo.
+  const adjustedCardHeight = isCompact ? cardHeight * 1.02 : cardHeight * 1.04;
+
+  // Rebalanceo de alturas.
+  const imageHeightPercent = isCompact ? '68%' : '70%';
+  const footerHeightPercent = isCompact ? '32%' : '30%';
+
+  const { visibleGenres, hiddenGenresCount } = useMemo(
+    () => pickVisibleGenres(book.genres, isCompact),
+    [book.genres, isCompact],
+  );
+
   return (
     <Card
       variant="elevated"
       size="md"
       className="overflow-hidden rounded-3xl p-0 shadow-hard-2 bg-white"
-      style={{ 
-        width: cardWidth, 
-        height: cardHeight,
+      style={{
+        width: cardWidth,
+        height: adjustedCardHeight,
         borderWidth: 1,
         borderColor: isDark ? '#3e2723' : '#fdfbf7',
       }}
     >
-      <Box style={{ height: '75%', width: '100%' }}>
+      <Box style={{ height: imageHeightPercent, width: '100%' }}>
         <Image
           source={{ uri: heroPhoto }}
           alt={book.titulo ?? 'Libro'}
@@ -94,60 +135,92 @@ export default function BookCard({ card, onTap }: BookCardProps) {
         </HStack>
       </Box>
 
-      <VStack 
-        className="bg-[#fdfbf7] p-5 gap-2 rounded-b-3xl" 
-        style={{ height: '25%' }}
+      <VStack
+        className="bg-[#fdfbf7] p-4 gap-1.5 rounded-b-3xl"
+        style={{ height: footerHeightPercent }}
       >
-        <Heading
-          size="lg"
-          className="text-[#3e2723] font-bold leading-tight"
-          numberOfLines={2}
-        >
-          {book.titulo ?? 'Sin título'}
-        </Heading>
+        <View style={{ minWidth: 0, width: '100%' }}>
+          <Text
+            size="xl"
+            className="text-[#3e2723] font-bold leading-tight web:block web:w-full web:truncate"
+            numberOfLines={1}
+            ellipsizeMode="tail"
+            allowFontScaling={false}
+            style={{ width: '100%', flexShrink: 1 }}
+          >
+            {book.titulo ?? 'Sin titulo'}
+          </Text>
+        </View>
 
-        <Text size="sm" className="text-[#3e2723] font-medium">
+        <Text size="sm" className="text-[#3e2723] font-medium" numberOfLines={1}>
           por {book.autor ?? 'Autor desconocido'}
         </Text>
 
-        <HStack className="items-center justify-between gap-2 mt-auto">
-          <HStack className="items-center gap-2 flex-shrink-0">
-            <View className="w-6 h-6 rounded-full bg-[#e07a5f] overflow-hidden border border-white shadow-sm">
-              {owner.fotoPerfilUrl ? (
-                <Image
-                  source={{ uri: owner.fotoPerfilUrl }}
-                  alt={owner.username}
-                  size="none"
-                  className="w-full h-full"
-                  resizeMode="cover"
-                />
-              ) : (
-                <View className="w-full h-full bg-[#e07a5f] items-center justify-center">
-                  <Text className="text-white text-[10px] font-bold">
-                    {owner.username.charAt(0).toUpperCase()}
-                  </Text>
-                </View>
-              )}
-            </View>
-            <Text size="xs" className="text-[#3e2723] font-bold" numberOfLines={1}>
-              {owner.username}
-            </Text>
-          </HStack>
+        <HStack className="items-center gap-2 mt-auto" style={{ minWidth: 0 }}>
+          <View className="w-6 h-6 rounded-full bg-[#e07a5f] overflow-hidden border border-white shadow-sm">
+            {owner.fotoPerfilUrl ? (
+              <Image
+                source={{ uri: owner.fotoPerfilUrl }}
+                alt={owner.username}
+                size="none"
+                className="w-full h-full"
+                resizeMode="cover"
+              />
+            ) : (
+              <View className="w-full h-full bg-[#e07a5f] items-center justify-center">
+                <Text className="text-white text-[10px] font-bold">
+                  {owner.username.charAt(0).toUpperCase()}
+                </Text>
+              </View>
+            )}
+          </View>
 
-          <HStack className="gap-1.5 flex-wrap justify-end flex-1">
-            {book.genres.slice(0, 2).map((genre) => (
-              <Badge
-                key={genre.id}
-                action="muted"
-                variant="solid"
-                className="rounded-full bg-[#f2cc8f] border-0 px-2.5 py-1"
+          <Text
+            size="xs"
+            className="text-[#3e2723] font-bold"
+            numberOfLines={1}
+            ellipsizeMode="tail"
+            style={{ flexShrink: 1, minWidth: 0 }}
+          >
+            {owner.username}
+          </Text>
+        </HStack>
+
+        <HStack
+          className="items-center gap-1.5 mt-1"
+          style={{
+            minWidth: 0,
+            flexWrap: 'nowrap',
+            overflow: 'hidden',
+          }}
+        >
+          {visibleGenres.map((genre) => (
+            <Badge
+              key={genre.id}
+              action="muted"
+              variant="solid"
+              className="rounded-full bg-[#f2cc8f] border-0 px-2.5 py-1"
+            >
+              <BadgeText
+                className="text-[#3e2723] text-[10px] normal-case font-medium"
+                numberOfLines={1}
               >
-                <BadgeText className="text-[#3e2723] text-[10px] normal-case font-medium">
-                  {genre.name}
-                </BadgeText>
-              </Badge>
-            ))}
-          </HStack>
+                {genre.name}
+              </BadgeText>
+            </Badge>
+          ))}
+
+          {hiddenGenresCount > 0 ? (
+            <Badge
+              action="muted"
+              variant="solid"
+              className="rounded-full bg-[#f2cc8f] border-0 px-2.5 py-1"
+            >
+              <BadgeText className="text-[#3e2723] text-[10px] normal-case font-medium">
+                +{hiddenGenresCount}
+              </BadgeText>
+            </Badge>
+          ) : null}
         </HStack>
       </VStack>
     </Card>


### PR DESCRIPTION
Se ha comprobado que siempre funcione el botón de ir hacia atrás y se ha adaptado las tarjetas para que los datos no se pisen, en detalle:
- Se ha adaptado las tarjetas de los libros en el matcher para que se vea bien en ordenador, iphone y android
- Se ha aumentado la tarjeta para que los géneros tengan su propio espacio
- Se ha hecho que el título del libro salga parcialmente acortado si este supera el tamaño de la tarjeta 
- Se ha comprobado que el botón de ir hacia atrás siempre funciona

Se ha encontrado los siguientes problemas:
- El botón de ir hacia atrás siempre funciona, sin embargo, en general hay veces que da fallo el matcher. Falla tanto el match, como el no match y el volver hacia atrás. (Comprobar por quien haya hecho el matcher)
- En android hay cosas que no aparecen, por ejemplo la animación de las tarjetas de los libros al hacer el swipe de difumidado a no difumido.

Refs: #59