### PR TITLE
fix: arreglo botón volver atrás pantalla no hay libros

### DIFF
--- a/app/(tabs)/matcher.tsx
+++ b/app/(tabs)/matcher.tsx
@@ -300,6 +300,26 @@ export default function MatcherScreen() {
           >
             <Text style={{ color: '#fdfbf7', fontWeight: '600' }}>Refrescar</Text>
           </Pressable>
+          <Pressable
+            onPress={handleUndo}
+            disabled={!canUndo}
+            style={[
+              styles.actionButton,
+              {
+                marginTop: 24,
+                width: SCREEN_WIDTH * MATCHER_LAYOUT.buttons.undoButtonPercent,
+                height: SCREEN_WIDTH * MATCHER_LAYOUT.buttons.undoButtonPercent,
+                backgroundColor: canUndo ? '#f2cc8f' : '#e8e8e8',
+                opacity: canUndo ? 1 : 0.4,
+              },
+            ]}
+          >
+            <Ionicons
+              name="arrow-undo"
+              size={SCREEN_WIDTH * MATCHER_LAYOUT.buttons.undoButtonPercent * MATCHER_LAYOUT.buttons.iconSizeRatio}
+              color={canUndo ? '#3e2723' : '#bbb'}
+            />
+          </Pressable>
         </View>
       </View>
     );


### PR DESCRIPTION
Se ha añadido el botón para volver al libro anterior en la pantalla que salta cuando ya no hay más libros que mostrar en el matcher.