### PR TITLE
127 frontend corregir problemas navegacion

### DIFF
--- a/app/books/[id]/edit.tsx
+++ b/app/books/[id]/edit.tsx
@@ -76,7 +76,7 @@ export default function EditBookScreen() {
         cover: toCoverEnum(cover),
         observaciones: description,
       });
-      router.replace("/profile?message=updated" as any);
+      router.dismissTo("/profile?message=updated" as any);
     } catch {
       setError("No se pudo guardar el libro.");
     }

--- a/app/books/[id]/index.tsx
+++ b/app/books/[id]/index.tsx
@@ -67,7 +67,7 @@ export default function BookDetailScreen() {
       if (!id) return;
       await deleteBook(Number(id));
       setShowDeleteModal(false);
-      router.replace("/profile?message=deleted" as any);
+      router.dismissTo("/profile?message=deleted" as any);
     } catch {
       setError("No se pudo eliminar el libro.");
     }

--- a/app/subscription.tsx
+++ b/app/subscription.tsx
@@ -224,7 +224,7 @@ export default function SubscriptionScreen() {
         }}
       >
         <TouchableOpacity
-          onPress={() => router.back()}
+          onPress={() => router.dismiss()}
           hitSlop={{ top: 12, bottom: 12, left: 12, right: 12 }}
         >
           <FontAwesome name="chevron-left" size={18} color="#8B7355" />

--- a/app/subscription.tsx
+++ b/app/subscription.tsx
@@ -11,7 +11,6 @@ import {
   View,
 } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
-import { useAuth } from "@/contexts/AuthContext";
 import { useSubscription } from "@/contexts/SubscriptionContext";
 import { ConfirmModal } from "@/components/ConfirmationModal";
 import FontAwesome from "@expo/vector-icons/FontAwesome";
@@ -26,7 +25,8 @@ if (Platform.OS !== "web") {
 const openStripePopup = (
   url: string,
   onSuccess: () => void,
-  onCancel: () => void
+  onCancel: () => void,
+  onPopupClosed: () => void
 ) => {
   const width = 500;
   const height = 700;
@@ -45,26 +45,31 @@ const openStripePopup = (
     return;
   }
 
-  // Check if popup was closed or redirected
+  let resolved = false;
+
   const checkPopup = setInterval(() => {
     try {
       if (popup.closed) {
         clearInterval(checkPopup);
-        // User closed the popup manually
-        onCancel();
+        if (!resolved) {
+          // Popup closed without us detecting the redirect URL.
+          // Could be success OR cancel — verify with backend.
+          onPopupClosed();
+        }
         return;
       }
 
-      // Try to read URL (will fail if still on Stripe domain due to CORS)
       const currentUrl = popup.location?.href;
-      if (currentUrl && (currentUrl.includes("status=success") || currentUrl.includes("status=cancelled"))) {
+      if (currentUrl && currentUrl.includes("status=success")) {
+        resolved = true;
         clearInterval(checkPopup);
         popup.close();
-        if (currentUrl.includes("status=success")) {
-          onSuccess();
-        } else {
-          onCancel();
-        }
+        onSuccess();
+      } else if (currentUrl && currentUrl.includes("status=cancelled")) {
+        resolved = true;
+        clearInterval(checkPopup);
+        popup.close();
+        onCancel();
       }
     } catch {
       // Cross-origin - popup is still on Stripe, keep waiting
@@ -83,14 +88,12 @@ const openStripePopup = (
 export default function SubscriptionScreen() {
   const router = useRouter();
   const { bottom } = useSafeAreaInsets();
-  const { userPlan } = useAuth();
   const {
     isPremium,
     subscriptionStatus,
     loading,
     getCheckoutUrl,
     cancelSubscription,
-    refreshStatus,
     syncFromStripe,
   } = useSubscription();
 
@@ -102,15 +105,34 @@ export default function SubscriptionScreen() {
 
   // ── Handle successful payment ──────────────────────────────────────
 
+  const syncWithRetries = useCallback(async (maxRetries = 3, delayMs = 2000): Promise<boolean> => {
+    for (let i = 0; i < maxRetries; i++) {
+      if (i > 0) await new Promise(r => setTimeout(r, delayMs));
+      const status = await syncFromStripe();
+      if (status?.isPremium) return true;
+    }
+    return false;
+  }, [syncFromStripe]);
+
   const handlePaymentSuccess = useCallback(async () => {
-    setTimeout(async () => {
-      await syncFromStripe();
+    const success = await syncWithRetries();
+    if (success) {
       Alert.alert(
         "¡Suscripción activada!",
         "Ahora eres un usuario Premium. Disfruta de todas las funciones."
       );
-    }, 2000);
-  }, [syncFromStripe]);
+    }
+  }, [syncWithRetries]);
+
+  const handlePopupClosed = useCallback(async () => {
+    const success = await syncWithRetries();
+    if (success) {
+      Alert.alert(
+        "¡Suscripción activada!",
+        "Ahora eres un usuario Premium. Disfruta de todas las funciones."
+      );
+    }
+  }, [syncWithRetries]);
 
   // ── Checkout: WebView (native) or popup (web) ──────────────────────
 
@@ -120,11 +142,11 @@ export default function SubscriptionScreen() {
       const url = await getCheckoutUrl();
 
       if (Platform.OS === "web") {
-        // Web: use popup window (faster than iframe, Stripe blocks iframes)
         openStripePopup(
           url,
           handlePaymentSuccess,
-          () => {} // onCancel - do nothing
+          () => {},
+          handlePopupClosed
         );
       } else {
         // Native: use WebView modal

--- a/app/subscription.tsx
+++ b/app/subscription.tsx
@@ -224,7 +224,7 @@ export default function SubscriptionScreen() {
         }}
       >
         <TouchableOpacity
-          onPress={() => router.replace("/(tabs)/matcher")}
+          onPress={() => router.back()}
           hitSlop={{ top: 12, bottom: 12, left: 12, right: 12 }}
         >
           <FontAwesome name="chevron-left" size={18} color="#8B7355" />

--- a/contexts/SubscriptionContext.tsx
+++ b/contexts/SubscriptionContext.tsx
@@ -25,8 +25,8 @@ interface SubscriptionContextType {
   cancelSubscription: () => Promise<void>;
   /** Re-fetches subscription status from backend */
   refreshStatus: () => Promise<void>;
-  /** Syncs subscription directly from Stripe API (webhook-free fallback) */
-  syncFromStripe: () => Promise<void>;
+  /** Syncs subscription directly from Stripe API. Returns the status. */
+  syncFromStripe: () => Promise<SubscriptionStatus | null>;
 }
 
 const SubscriptionContext = createContext<SubscriptionContextType>({
@@ -36,7 +36,7 @@ const SubscriptionContext = createContext<SubscriptionContextType>({
   getCheckoutUrl: async () => '',
   cancelSubscription: async () => {},
   refreshStatus: async () => {},
-  syncFromStripe: async () => {},
+  syncFromStripe: async () => null,
 });
 
 export function SubscriptionProvider({ children }: { children: ReactNode }) {
@@ -64,14 +64,16 @@ export function SubscriptionProvider({ children }: { children: ReactNode }) {
     await refreshStatus();
   }, [refreshStatus]);
 
-  const syncFromStripe = useCallback(async () => {
+  const syncFromStripe = useCallback(async (): Promise<SubscriptionStatus | null> => {
     try {
       const status = await syncSubscriptionFromStripe();
       setSubscriptionStatus(status);
       await refreshUserPlan();
+      return status;
     } catch (error) {
       console.warn('[SubscriptionContext] syncFromStripe failed, falling back to refreshStatus:', error);
       await refreshStatus();
+      return null;
     }
   }, [refreshStatus, refreshUserPlan]);
 


### PR DESCRIPTION
Además de las flechas de navegación hacia atrás se cambia el comportamiento de Stripe en web para usuarios. Antes había ocasiones en que el flujo no respondía, funcionaba aleatoriamente. El problema se debía a condiciones de carrera por el cierre de la ventana: El flujo de ahora hace lo siguiente:

1. popup.closed sin haber leído la URL → onPopupClosed() → llama a syncWithRetries() que pregunta al backend si el usuario es premium ahora hasta 3 veces. Si sí, alert de éxito. Si no, silencio.                                                                                                      
2. Polling lee status=success en la URL → marca resolved = true → cierra popup → onSuccess() → llama a syncWithRetries() → alert de éxito.                                                                             
3. Polling lee status=cancelled en la URL → marca resolved = true → cierra popup → onCancel() → que es () => {}, no hace nada. 

Con la extensión debería seguir funcionando porque no se ha tocado el WebView.